### PR TITLE
Adds reference handling for appointments

### DIFF
--- a/app/api/appointments/route.js
+++ b/app/api/appointments/route.js
@@ -1,9 +1,10 @@
 import connectMongoDB from "@/libs/mongodb";
 import { ObjectId } from "mongodb";
+import { formatDate } from "@/app/utils/formatDate";
 
 const { db } = await connectMongoDB();
 
-// Add a new document
+// Add a new appointment
 export async function POST(request) {
   try {
     console.log("POST request received");
@@ -22,7 +23,7 @@ export async function POST(request) {
 
     return new Response(
       JSON.stringify({
-        message: `New document added to ${collection} successfully.`,
+        message: `New appointment added to ${collection} successfully.`,
       }),
       {
         headers: { "Content-Type": "application/json" },
@@ -40,7 +41,7 @@ export async function POST(request) {
   }
 }
 
-// get document(s) with optional parameters
+// get appointments with optional parameters. Populate referenced documents and destructure
 export async function GET(request) {
   try {
     console.log(`GET request received`);
@@ -58,9 +59,84 @@ export async function GET(request) {
       query.client = ObjectId.createFromHexString(params.get("client"));
     }
 
-    const data = await db.collection(collection).find(query).toArray();
-    console.log(data);
-    return new Response(JSON.stringify(data), {
+    let aggregationPipeline = [
+      { $match: query }, // Same as .find(query)
+    ];
+
+    // Get referenced documents for appointments
+    if (collection === "appointments") {
+      aggregationPipeline.push(
+        {
+          $lookup: {
+            from: "services", // Name of the collection to reference
+            localField: "service", // Field in the current collection to match
+            foreignField: "_id", // Field in the related collection to match
+            as: "service", // Name of the field to store the populated documents
+          },
+        },
+        {
+          $lookup: {
+            from: "clients",
+            localField: "client",
+            foreignField: "_id",
+            as: "client",
+          },
+        },
+        {
+          $lookup: {
+            from: "therapists",
+            localField: "therapist",
+            foreignField: "_id",
+            as: "therapist",
+          },
+        }
+        // {
+        //   $unwind: "$service", // change array to a single document
+        // },
+        // {
+        //   $unwind: "$client",
+        // },
+        // {
+        //   $unwind: "$therapist",
+        // }
+      );
+    }
+
+    const data = await db
+      .collection(collection)
+      .aggregate(aggregationPipeline)
+      .toArray();
+
+    // Destructure the references
+    const destructuredData = data.map((appointment) => {
+      const { _id, service, therapist, status } = appointment;
+      const { date, time } = formatDate(appointment.startTime); // Format date and time
+      const serviceName = service[0].name; // service name
+      const duration = service[0].length; // service duration
+      const therapistName =
+        therapist[0].firstName + " " + therapist[0].lastName;
+
+      // console.log({
+      //   _id,
+      //   date,
+      //   time,
+      //   serviceName,
+      //   duration,
+      //   therapistName,
+      //   status,
+      // });
+      return {
+        _id,
+        date,
+        time,
+        serviceName,
+        duration,
+        therapistName,
+        status,
+      };
+    });
+
+    return new Response(JSON.stringify(destructuredData), {
       headers: { "Content-Type": "application/json" },
       status: 200,
     });
@@ -116,16 +192,18 @@ export async function PUT(request) {
 
     const { ...updatedFields } = body;
 
-    const result = await db.collection(collection).findOneAndUpdate(
-      { _id: ObjectId.createFromHexString(id) },
-      { $set: updatedFields },
-      { returnOriginal: false } // return the updated document not the original
-    );
+    const result = await db
+      .collection(collection)
+      .findOneAndUpdate(
+        { _id: ObjectId.createFromHexString(id) },
+        { $set: updatedFields },
+        { returnOriginal: false }
+      );
 
     return new Response(
       JSON.stringify({
         message: `Document id#${id} in ${collection} updated successfully.`,
-        updatedDocument: result.value, // send the updated document back so the state can be updated without another query
+        updatedDocument: result.value,
       }),
       {
         headers: { "Content-Type": "application/json" },

--- a/app/utils/formatDate.js
+++ b/app/utils/formatDate.js
@@ -1,0 +1,18 @@
+// format date from '2024-03-25T15:00' to:
+//  date: Mar 25, 2024
+//  time: 3:00 PM
+export function formatDate(dateString) {
+  const date = new Date(dateString);
+  return {
+    date: date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }),
+    time: date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true,
+    }),
+  };
+}

--- a/libs/mongodb.js
+++ b/libs/mongodb.js
@@ -14,7 +14,7 @@ const connectMongoDB = async () => {
 
     await client.connect();
 
-    const db = client.db(process.env.MONGO_DB_NAME);
+    const db = client.db();
 
     // Cache the client and db globally for reuse
     cachedClient = client;


### PR DESCRIPTION
When fetching a document that has a reference to another document, perform a $lookup subquery to retrieve the reference data as well. Once fetched, it is destructured and returned.

This was made for fetching appointments, but it is not yet implemented for other collections with references.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oribermudez/revitalize/14)
<!-- Reviewable:end -->
