### PR TITLE
Update appointments pages to work with new API

### DIFF
--- a/app/(menu)/appointments/page.js
+++ b/app/(menu)/appointments/page.js
@@ -2,13 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { Card, Button } from "@material-tailwind/react";
-import { AppStateProvider } from "../../global-state/AppStateContext";
+import { AppStateProvider } from "@/app/global-state/AppStateContext";
 import Breadcrumbs from "@/app/components/Breadcrumbs";
 import HighlightCards from "@/app/components/client-dashboard/HighlightCards";
-import Appointment from "@/app/components/client-appointments/Appointment";
+import Appointment from "@/app/components/therapist-appointments/Appointment";
 import MyCalendar from "@/app/components/MyCalendar";
-import NewAppointment from "@/app/components/client-appointments/NewAppointment";
-import AppointmentDetails from "@/app/components/client-appointments/AppointmentDetails";
+import NewAppointment from "@/app/components/therapist-appointments/NewAppointment";
+import AppointmentDetails from "@/app/components/therapist-appointments/AppointmentDetails";
 import MyModal from "@/app/components/MyModal";
 import { PlusIcon } from "@heroicons/react/24/outline";
 
@@ -33,16 +33,19 @@ const ClientAppointments = () => {
     setIsOpen(false);
   };
 
-  const clientId = "65ff54ea5c64ef8e0707f900"; //TODO: get client id from auth
+  const therapistId = "65fcee40d176ae6318341362";
 
   useEffect(() => {
     const fetchAppointments = async () => {
-      const response = await fetch(`/api/appointments?client=${clientId}`, {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      });
+      const response = await fetch(
+        `/api/appointments?therapist=${therapistId}`,
+        {
+          method: "GET",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
       const data = await response.json();
       setAppointments(data);
     };

--- a/app/api/appointments/route.js
+++ b/app/api/appointments/route.js
@@ -1,16 +1,33 @@
-import { NextResponse } from 'next/server';
-import { getAllAppointments, createAppointment } from '@/database/services/appointment';
+import { NextResponse } from "next/server";
+import {
+  getAllAppointments,
+  getAppointmentsForClient,
+  getAppointmentsForTherapist,
+  createAppointment,
+} from "@/database/services/appointment";
 
-export const GET = async () => {
+export const GET = async (req) => {
   try {
-    const appointments = await getAllAppointments();
+    const clientId = req.nextUrl.searchParams.get("client");
+    const therapistId = req.nextUrl.searchParams.get("therapist");
+    let appointments;
+    if (clientId) {
+      appointments = await getAppointmentsForClient(clientId);
+    } else if (therapistId) {
+      appointments = await getAppointmentsForTherapist(therapistId);
+    } else {
+      appointments = await getAllAppointments();
+    }
     return NextResponse.json(appointments, {
       status: 200,
     });
   } catch (error) {
-    return NextResponse.json({ error: 'Could not fetch appointments' }, { status: 500 });
+    return NextResponse.json(
+      { error: "Could not fetch appointments" },
+      { status: 500 }
+    );
   }
-}
+};
 
 export const POST = async (req) => {
   const appointmentData = await req.json();
@@ -20,6 +37,9 @@ export const POST = async (req) => {
       status: 200,
     });
   } catch (error) {
-    return NextResponse.json({ error: 'Could not create new appointment' }, { status: 500 });
+    return NextResponse.json(
+      { error: "Could not create new appointment" },
+      { status: 500 }
+    );
   }
-}
+};

--- a/app/client/appointments/page.js
+++ b/app/client/appointments/page.js
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, Button } from "@material-tailwind/react";
+import { AppStateProvider } from "../../global-state/AppStateContext";
+import Breadcrumbs from "@/app/components/Breadcrumbs";
+import HighlightCards from "@/app/components/client-dashboard/HighlightCards";
+import Appointment from "@/app/components/client-appointments/Appointment";
+import MyCalendar from "@/app/components/MyCalendar";
+import NewAppointment from "@/app/components/client-appointments/NewAppointment";
+import MyModal from "@/app/components/MyModal";
+import { PlusIcon } from "@heroicons/react/24/outline";
+
+const ClientAppointments = () => {
+  const [appointments, setAppointments] = useState([]);
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsOpen(false);
+  };
+
+  const clientId = "65d7c3486158325305bfbe33"; // 65d7c3486158325305bfbe33
+
+  useEffect(() => {
+    const fetchAppointments = async () => {
+      const response = await fetch(`/api/appointments?client=${clientId}`, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      const data = await response.json();
+      setAppointments(data);
+    };
+    fetchAppointments();
+  }, []);
+
+  const now = new Date();
+  const futureAppointments = appointments.filter(
+    (appointment) => new Date(appointment.date) >= now
+  );
+  const pastAppointments = appointments.filter(
+    (appointment) => new Date(appointment.date) < now
+  );
+
+  return (
+    <AppStateProvider>
+      <div className="col-span-4 w-full h-full p-8 mt-20 lg:m-20">
+        <h2 className="text-[#2D4635] font-bold text-xl">Your Appointments</h2>
+        <Breadcrumbs />
+        <Button
+          className="bg-main py-2 pr-6 pl-4 text-sm flex items-center"
+          onClick={openModal}
+        >
+          <PlusIcon className="h-4 w-4 mr-2" />
+          New Appointment
+        </Button>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Appointment type="future" appointments={futureAppointments} />
+          <Appointment type="past" appointments={pastAppointments} />
+        </div>
+      </div>
+      <MyModal isOpen={isOpen} onClose={closeModal}>
+        <NewAppointment onClose={closeModal} />
+      </MyModal>
+    </AppStateProvider>
+  );
+};
+
+export default ClientAppointments;

--- a/app/components/client-appointments/Appointment.js
+++ b/app/components/client-appointments/Appointment.js
@@ -1,0 +1,50 @@
+import { Card } from "@material-tailwind/react";
+
+const Appointment = ({ type, appointments }) => {
+  return (
+    <Card className="rounded-md h-42 p-5 flex flex-col">
+      <h4 className="my-4 ml-2 font-bold text-xl">
+        {type === "future" ? "Upcoming Appointments" : "Appointment History"}
+      </h4>
+      {appointments && (
+        <div className="flex flex-col">
+          {appointments.map((appointment) => (
+            <div
+              key={appointment._id}
+              className="flex flex-col justify-center "
+            >
+              <div className="text-gray-900 hover:text-royal text-sm flex items-center hover:bg-accent/20 p-4 rounded-md cursor-pointer">
+                <div className="rounded-full w-4 h-4 border border-accent bg-accent" />
+                <div className="flex flex-col">
+                  <div className="ml-4">
+                    <span className="font-bold font">
+                      {appointment.duration && appointment.serviceName
+                        ? `${appointment.duration}min ${appointment.serviceName}`
+                        : "No service set"}
+                    </span>
+                  </div>
+                  <div className="ml-4">
+                    <span className="font-semibold">
+                      {appointment.date && appointment.time
+                        ? `at ${appointment.time} on  ${appointment.date}`
+                        : "No date and time set"}
+                    </span>
+                  </div>
+                  <div className="ml-4">
+                    <span className="font-semibold">
+                      {appointment.therapistName
+                        ? `with ${appointment.therapistName}`
+                        : "No therapist set"}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default Appointment;

--- a/app/components/client-appointments/AppointmentDetails.js
+++ b/app/components/client-appointments/AppointmentDetails.js
@@ -1,0 +1,75 @@
+import { Card } from "@material-tailwind/react";
+import { formatDate } from "@/app/utils/formatDate";
+
+const Appointment = ({ appointment }) => {
+  console.log(appointment);
+  return (
+    <Card className="rounded-md h-42 p-5 flex flex-col">
+      <h4 className="my-4 ml-2 font-bold text-xl">Appointment Details</h4>
+      {appointment && (
+        <div className="flex flex-col">
+          <div className="bg-accent/20 p-2 rounded-md">
+            <div>
+              <span className="font-bold font">Appointment Date:</span>
+              <span className="font">
+                {appointment.startTime
+                  ? ` ${formatDate(appointment.startTime)}`
+                  : " No appointment date/time set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Location:</span>
+              <span className="font">
+                {appointment.therapist?.address
+                  ? ` $${appointment.therapist.address.street}, ${appointment.therapist.address.city} ${appointment.therapist.address.province}, ${appointment.therapist.address.postalCode}`
+                  : " No street address set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Therapist:</span>
+              <span className="font">
+                {appointment.therapist?.name
+                  ? ` ${appointment.therapist.name}`
+                  : " No therapist set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Service:</span>
+              <span className="font">
+                {appointment.service?.length
+                  ? ` ${appointment.service.name}`
+                  : " No service set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Duration:</span>
+              <span className="font">
+                {appointment.service?.length
+                  ? ` ${appointment.service.length} minutes`
+                  : " No service length set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Price:</span>
+              <span className="font">
+                {appointment.service?.price
+                  ? ` $${Number(appointment.service.price).toFixed(2)} CAD`
+                  : " No service price set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Description:</span>
+              <span className="font">
+                {appointment.service?.description
+                  ? ` ${appointment.service.description}`
+                  : " No service description set"}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default Appointment;

--- a/app/components/client-appointments/NewAppointment.js
+++ b/app/components/client-appointments/NewAppointment.js
@@ -1,0 +1,141 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  Input,
+  Select,
+  Option,
+  Typography,
+} from "@material-tailwind/react";
+import "react-datepicker/dist/react-datepicker.css";
+import { useAppState } from "@/app/global-state/AppStateContext";
+import { ADD_APPOINTMENT, addAppointment } from "@/app/global-state/actions";
+
+const NewAppointment = ({ onClose }) => {
+  const { dispatch } = useAppState();
+
+  const [formData, setFormData] = useState({
+    startTime: "",
+    service: "",
+    therapist: "",
+    client: "65d7c3486158325305bfbe33",
+    status: "pending",
+  });
+  const [services, setServices] = useState([]);
+  const [therapists, setTherapists] = useState([]);
+  const [clients, setClients] = useState([]);
+
+  useEffect(() => {
+    fetch(`/api/services`)
+      .then((response) => response.json())
+      .then((data) => setServices(data))
+      .catch((error) => console.error("Error fetching services:", error));
+    fetch("/api/therapists")
+      .then((response) => response.json())
+      .then((data) => setTherapists(data))
+      .catch((error) => console.error("Error fetching therapists:", error));
+    fetch("/api/clients")
+      .then((response) => response.json())
+      .then((data) => setClients(data))
+      .catch((error) => console.error("Error fetching clients:", error));
+  }, []);
+
+  const handleChange = (e) => {
+    const { id, value } = e.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [id]: value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    console.log("Submitting new appointment: ", formData);
+
+    try {
+      const response = await fetch("/api/appointments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      });
+    } catch (error) {
+      console.error("Error submitting new appointment form:", error);
+    }
+    dispatch(addAppointment({ type: ADD_APPOINTMENT, payload: formData }));
+
+    onClose();
+  };
+
+  return (
+    <Card className="bg-white rounded-md p-6">
+      <form onSubmit={handleSubmit}>
+        <CardBody>
+          <Typography variant="h5" color="blue-gray" className="mb-10">
+            New Appointment
+          </Typography>
+          <div className="mb-6">
+            <input
+              type="datetime-local"
+              id="startTime"
+              placeholderText="Select a date/time"
+              selected={formData.startDate}
+              onChange={handleChange}
+              className="w-full p-2 border-b-2 border-slate-300 outline-none focus:border-main"
+              dateFormat="dd/MM/yyyy"
+              required
+            />
+          </div>
+          <div className="mb-6">
+            <select
+              id="service"
+              value={formData.service}
+              onChange={handleChange}
+              className="w-full p-2 border-b-2 focus:border-main outline-none"
+              required
+            >
+              <option value="" disabled>
+                Select Service
+              </option>
+              {services.map((service) => (
+                <option key={service._id} value={service._id}>
+                  {service.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="mb-6">
+            <select
+              id="therapist"
+              value={formData.therapist}
+              onChange={handleChange}
+              className="w-full p-2 border-b-2 focus:border-main outline-none"
+              required
+            >
+              <option value="" disabled className="!text-grey-300">
+                Select Therapist
+              </option>
+              {therapists.map((therapist) => (
+                <option key={therapist._id} value={therapist._id}>
+                  {therapist.firstName + " " + therapist.lastName}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardBody>
+        <CardFooter>
+          <Button type="submit" className="w-full bg-main text-sm mt-0">
+            Submit
+          </Button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+};
+export default NewAppointment;

--- a/app/components/therapist-appointments/Appointment.js
+++ b/app/components/therapist-appointments/Appointment.js
@@ -34,9 +34,9 @@ const Appointment = ({ title, appointments, onAppointmentClick }) => {
                   </div>
                   <div className="ml-4">
                     <span className="font-semibold">
-                      {appointment.therapist.name
+                      {appointment.client
                         ? `with ${appointment.therapist.name}`
-                        : "No therapist set"}
+                        : "No client set"}
                     </span>
                   </div>
                 </div>

--- a/app/components/therapist-appointments/AppointmentDetails.js
+++ b/app/components/therapist-appointments/AppointmentDetails.js
@@ -1,0 +1,105 @@
+import { Card } from "@material-tailwind/react";
+import { formatDate } from "@/app/utils/formatDate";
+
+const Appointment = ({ appointment }) => {
+  console.log(appointment);
+  return (
+    <Card className="rounded-md h-42 p-5 flex flex-col">
+      <h4 className="my-4 ml-2 font-bold text-xl">Appointment Details</h4>
+      {appointment && (
+        <div className="flex flex-col">
+          <div className="bg-accent/20 p-2 rounded-md">
+            <div>
+              <span className="font-bold font">Appointment Date:</span>
+              <span className="font">
+                {appointment.startTime
+                  ? ` ${formatDate(appointment.startTime)}`
+                  : " No appointment date/time set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Service:</span>
+              <span className="font">
+                {appointment.service?.length
+                  ? ` ${appointment.service.name}`
+                  : " No service set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Duration:</span>
+              <span className="font">
+                {appointment.service?.length
+                  ? ` ${appointment.service.length} minutes`
+                  : " No service length set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Price:</span>
+              <span className="font">
+                {appointment.service?.price
+                  ? ` $${Number(appointment.service.price).toFixed(2)} CAD`
+                  : " No service price set"}
+              </span>
+            </div>
+            <div>
+              <span className="font-bold font">Description:</span>
+              <span className="font">
+                {appointment.service?.description
+                  ? ` $${appointment.service.description}`
+                  : " No service description set"}
+              </span>
+            </div>
+          </div>
+          {appointment.client ? (
+            <div className="bg-accent/20 p-2 rounded-md">
+              <div>
+                <span className="font-bold font">Client:</span>
+                <span className="font">
+                  {appointment.client?.name
+                    ? ` ${appointment.client.name}`
+                    : " No client set"}
+                </span>
+              </div>
+              <div>
+                <span className="font-bold font">Email:</span>
+                <span className="font">
+                  {appointment.client?.email
+                    ? ` ${appointment.client.email}`
+                    : " No client set"}
+                </span>
+              </div>
+              <div>
+                <span className="font-bold font">Phone:</span>
+                <span className="font">
+                  {appointment.client?.phone
+                    ? ` ${appointment.client.phone}`
+                    : " No client set"}
+                </span>
+              </div>
+              <div>
+                <span className="font-bold font">Address:</span>
+                <span className="font">
+                  {appointment.client?.address
+                    ? ` ${appointment.client.address.street} ${appointment.client.address.city} ${appointment.client.address.province} ${appointment.client.address.postalCode}`
+                    : " No client set"}
+                </span>
+              </div>
+              <div>
+                <span className="font-bold font">Massages Taken:</span>
+                <span className="font">
+                  {appointment.client?.massagesTaken
+                    ? ` ${appointment.client.massagesTaken}`
+                    : " No client set"}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <div className="bg-accent/20 p-2 rounded-md">No client set.</div>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+export default Appointment;

--- a/app/components/therapist-appointments/NewAppointment.js
+++ b/app/components/therapist-appointments/NewAppointment.js
@@ -6,20 +6,27 @@ import {
   Card,
   CardBody,
   CardFooter,
+  Input,
+  Select,
+  Option,
   Typography,
 } from "@material-tailwind/react";
 import "react-datepicker/dist/react-datepicker.css";
+import { useAppState } from "@/app/global-state/AppStateContext";
 
 const NewAppointment = ({ onClose }) => {
+  const { dispatch } = useAppState();
+
   const [formData, setFormData] = useState({
     startTime: "",
     service: "",
-    therapist: "",
-    client: "65ff54ea5c64ef8e0707f900", //TODO: get client id from auth
+    therapist: "65fcee40d176ae6318341362", //TODO: get this from the logged in user
+    client: "",
     status: "pending",
   });
   const [services, setServices] = useState([]);
   const [therapists, setTherapists] = useState([]);
+  const [clients, setClients] = useState([]);
 
   useEffect(() => {
     fetch(`/api/services`)
@@ -30,6 +37,10 @@ const NewAppointment = ({ onClose }) => {
       .then((response) => response.json())
       .then((data) => setTherapists(data))
       .catch((error) => console.error("Error fetching therapists:", error));
+    fetch("/api/clients")
+      .then((response) => response.json())
+      .then((data) => setClients(data))
+      .catch((error) => console.error("Error fetching clients:", error));
   }, []);
 
   const handleChange = (e) => {
@@ -51,7 +62,6 @@ const NewAppointment = ({ onClose }) => {
         },
         body: JSON.stringify(formData),
       });
-      console.log("New appointment form submitted");
     } catch (error) {
       console.error("Error submitting new appointment form:", error);
     }
@@ -109,6 +119,25 @@ const NewAppointment = ({ onClose }) => {
               {therapists.map((therapist) => (
                 <option key={therapist._id} value={therapist._id}>
                   {therapist.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="mb-6">
+            <select
+              id="client"
+              value={formData.client}
+              onChange={handleChange}
+              className="w-full p-2 border-b-2 focus:border-main outline-none"
+              required
+            >
+              <option value="" disabled className="!text-grey-300">
+                Select Client
+              </option>
+              {clients.map((client) => (
+                <option key={client._id} value={client._id}>
+                  {client.name}
                 </option>
               ))}
             </select>

--- a/app/utils/formatDate.js
+++ b/app/utils/formatDate.js
@@ -1,19 +1,18 @@
-// Pass date string from DB to format into date and time
-// "2024-03-25T15:00"
-//    date: Mar 25, 2024
-//    time: 3:00 PM
+// Turns date into 2 parts: date and time
+// ex. dateString = "2024-03-25T15:00"
+//     returns: date: Mar 25, 2024
+//              time: 3:00 PM
 export function formatDate(dateString) {
   const date = new Date(dateString);
-  return {
-    date: date.toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    }),
-    time: date.toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "numeric",
-      hour12: true,
-    }),
-  };
+  const formattedDate = date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  const formattedTime = date.toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "numeric",
+    hour12: true,
+  });
+  return `${formattedDate} at ${formattedTime}`;
 }

--- a/app/utils/formatDate.js
+++ b/app/utils/formatDate.js
@@ -1,0 +1,19 @@
+// Pass date string from DB to format into date and time
+// "2024-03-25T15:00"
+//    date: Mar 25, 2024
+//    time: 3:00 PM
+export function formatDate(dateString) {
+  const date = new Date(dateString);
+  return {
+    date: date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }),
+    time: date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true,
+    }),
+  };
+}

--- a/database/services/appointment.js
+++ b/database/services/appointment.js
@@ -1,5 +1,5 @@
-import Appointment from '@/database/models/Appointment';
-import connectMongo from '@/database';
+import Appointment from "@/database/models/Appointment";
+import connectMongo from "@/database";
 
 await connectMongo();
 
@@ -9,7 +9,7 @@ export async function createAppointment(appointmentData) {
     await appointment.save();
     return appointment;
   } catch (error) {
-    console.error('Error creating appointment:', error);
+    console.error("Error creating appointment:", error);
     throw error;
   }
 }
@@ -17,12 +17,12 @@ export async function createAppointment(appointmentData) {
 export async function getAllAppointments() {
   try {
     const appointments = await Appointment.find()
-      .populate('service')
-      .populate('therapist')
-      .populate('client');
+      .populate("service")
+      .populate("therapist")
+      .populate("client");
     return appointments;
   } catch (error) {
-    console.error('Error fetching appointments:', error);
+    console.error("Error fetching appointments:", error);
     throw error;
   }
 }
@@ -30,25 +30,53 @@ export async function getAllAppointments() {
 export async function getAppointmentById(appointmentId) {
   try {
     const appointment = await Appointment.findById(appointmentId)
-      .populate('service')
-      .populate('therapist')
-      .populate('client');
+      .populate("service")
+      .populate("therapist")
+      .populate("client");
     return appointment;
   } catch (error) {
-    console.error('Error fetching appointment by ID:', error);
+    console.error("Error fetching appointment by ID:", error);
+    throw error;
+  }
+}
+
+export async function getAppointmentsForClient(clientId) {
+  try {
+    const appointments = await Appointment.find({ client: clientId })
+      .populate("service")
+      .populate("therapist");
+    return appointments;
+  } catch (error) {
+    console.error("Error fetching appointments by client ID:", error);
+    throw error;
+  }
+}
+
+export async function getAppointmentsForTherapist(therapistId) {
+  try {
+    const appointments = await Appointment.find({ therapist: therapistId })
+      .populate("service")
+      .populate("client");
+    return appointments;
+  } catch (error) {
+    console.error("Error fetching appointments by client ID:", error);
     throw error;
   }
 }
 
 export async function updateAppointment(appointmentId, updatedAppointmentData) {
   try {
-    const appointment = await Appointment.findByIdAndUpdate(appointmentId, updatedAppointmentData, { new: true })
-      .populate('service')
-      .populate('therapist')
-      .populate('client');
+    const appointment = await Appointment.findByIdAndUpdate(
+      appointmentId,
+      updatedAppointmentData,
+      { new: true }
+    )
+      .populate("service")
+      .populate("therapist")
+      .populate("client");
     return appointment;
   } catch (error) {
-    console.error('Error updating appointment:', error);
+    console.error("Error updating appointment:", error);
     throw error;
   }
 }
@@ -58,7 +86,7 @@ export async function deleteAppointment(appointmentId) {
     await Appointment.findByIdAndDelete(appointmentId);
     return true;
   } catch (error) {
-    console.error('Error deleting appointment:', error);
+    console.error("Error deleting appointment:", error);
     throw error;
   }
 }


### PR DESCRIPTION
Note: I added some code to the GET in the new appointments route, and added two functions in the appointment service so we can get appointments for a user's id. 

**Still work in progress, but this adds the functionality to:**
- Show upcoming appointments
- Show appointment history
- View details for an appointment (edit/delete NYI)
- Create a new appointment

**This is all for both the therapist and the client's appointments pages:** 
- Client: /client/appointments
- Therapist: /appointments

**Missing features / known issues**
- Since auth isn't implemented yet, I just hardcoded an id for the therapist and client. 
- Calendar component should be included once we figure out calendar/scheduling
- Availability is not considered when booking a new appointment
- Can make an appointment in the past
- Missing confirmation/summary when submitting an appointment
- No errors shown if something goes wrong (like mongo not connecting)
- No loading spinner for DB data
- Therapist page should have the appointments displayed in the table component that the dashboard page has
- Left menu button isn't working (should navigate to the page and highlight when on the page)
- Styling needs some work

### Upcoming/Past Appointments
![image](https://github.com/oribermudez/revitalize/assets/118098568/02dd8aa3-7b6a-424f-9edc-92c2bc1b79a0)

### Click on an appointment to see more details
![image](https://github.com/oribermudez/revitalize/assets/118098568/e15e80a2-cec6-4284-af16-4f55d73ca9f5)

### New appointment form 
![image](https://github.com/oribermudez/revitalize/assets/118098568/9ea79c98-dfa1-45bf-9bdd-8d39c3062cc9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oribermudez/revitalize/19)
<!-- Reviewable:end -->
